### PR TITLE
Install epdb

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -43,6 +43,7 @@ ansibullbot_packages:
   - python2-pip
   - gcc
   - python-devel
+  - python-epdb
 
 ansibullbot_recevier_pip_packages:
   - Flask


### PR DESCRIPTION
Sometimes we need to debug in production. When `ANSIBULLBOT_BREAKPOINTS` is set, `epdb` is used as a debugger.