### PR TITLE
Add branch config

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Role Variables
 | `ansibullbot_user` | `ansibot` | User account that will run `ansibullbot` |
 | `ansibullbot_group` | `{{ ansibullbot_user }}` | Group that `ansibullbot_user` belongs to. |
 | `ansibullbot_repo_url` | `https://github.com/ansible/ansibullbot` | URL of the ansibullbot git repo. |
+| `ansibullbot_branch` | `master` | Branch of the ansibullbot git repo to checkout. |
 | `ansibullbot_home_dir` | `/home/{{ ansibullbot_user }}` | Where to create home directory for Ansibullbot user. |
 | `ansibullbot_clone_path` | `{{ ansibullbot_home_dir }}/ansibullbot` | Where to clone the `ansibullbot` git repository. |
 | `ansibullbot_log_path` | `/var/log/ansibullbot.log` | Path to log file. |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,7 @@ ansibullbot_action: install
 ansibullbot_user: ansibot
 ansibullbot_group: "{{ ansibullbot_user }}"
 ansibullbot_repo_url: https://github.com/ansible/ansibullbot
+ansibullbot_branch: master
 ansibullbot_home_dir: /home/{{ ansibullbot_user }}
 ansibullbot_clone_path: "{{ ansibullbot_home_dir }}/ansibullbot"
 ansibullbot_log_path: /var/log/ansibullbot.log

--- a/tasks/install/main.yml
+++ b/tasks/install/main.yml
@@ -89,7 +89,7 @@
 
 - name: Checkout git repo
   git:
-    repo: https://github.com/ansible/ansibullbot
+    repo: "{{ ansibullbot_repo_url }}"
     dest: "{{ ansibullbot_clone_path }}"
     refspec: "{{ ansibullbot_branch }}"
     recursive: yes

--- a/tasks/install/main.yml
+++ b/tasks/install/main.yml
@@ -91,6 +91,7 @@
   git:
     repo: https://github.com/ansible/ansibullbot
     dest: "{{ ansibullbot_clone_path }}"
+    refspec: "{{ ansibullbot_branch }}"
     recursive: yes
     force: yes
   become: yes

--- a/tasks/update/main.yml
+++ b/tasks/update/main.yml
@@ -2,6 +2,7 @@
   git:
     repo: "{{ ansibullbot_repo_url }}"
     dest: "{{ ansibullbot_clone_path }}"
+    refspec: "{{ ansibullbot_branch }}"
     force: yes
   become: yes
   become_user: "{{ ansibullbot_user }}"


### PR DESCRIPTION
This does two things:
* Fixes the ansibullbot install case to use the ansibullbot_repo_url config setting just like the upgrade case does.
* Adds a configuration option to deploy a different branch.  (master vs main and maybe someone would be deploying from a feature branch)